### PR TITLE
Completed collections, posts, and users documentation.

### DIFF
--- a/developer/database.md
+++ b/developer/database.md
@@ -9,15 +9,19 @@ Filled when someone logs in with the API.
 Populated when the About and Privacy page are edited.
 
 ## `appmigrations`
+All database migrations that have been run on this database.
 
 ## `collectionattributes`
 Used for additional properties on collections.
 
 ## `collectionkeys`
+Public / private keypairs for all collections on the instance. Used to sign ActivityPub / fediverse requests.
 
 ## `collectionpasswords`
+Salted and hashed passwords for password-protected collections.
 
 ## `collectionredirects`
+Data about former `alias`es for collections that have had them changed, so that the old `alias` redirects visitors to the new one.
 
 ## `collections`
 Table that contains collections (i.e. "Blogs").
@@ -76,14 +80,19 @@ Table that contains data for posts within collections.
 * `content`: *text*.  **Cannot be null**.  The content of the post in plain text.
 
 ## `remotefollows`
+Data about which remote, i.e. ActivityPub / fediverse, users are following which collections.
 
 ## `remoteuserkeys`
+Public keys of all remote users.
 
 ## `remoteusers`
+Data needed to communicate with remote users.
 
 ## `userattributes`
+Additional attributes on users.
 
 ## `userinvites`
+User invite codes and metadata.
 
 ## `users`
 Table that contains user data.
@@ -99,4 +108,4 @@ Table that contains user data.
 * `created`: *datetime*.  **Cannot be null**.  Date and time account was created.
 
 ## `usersinvited`
-
+Data about which users were brought in by which user-invite.

--- a/developer/database.md
+++ b/developer/database.md
@@ -3,10 +3,10 @@
 The following is a description of the various database tables and attributes.  (This document is not yet complete).
 
 ## `accesstokens`
-Filled when someone logs in with the API.
+Generated user access tokens for accessing the API.
 
 ## `appcontent`
-Populated when the About and Privacy page are edited.
+Instance-level dynamic content, usually created via the admin dashboard, such as the About and Privacy pages.
 
 ## `appmigrations`
 All database migrations that have been run on this database.
@@ -59,13 +59,13 @@ Table that contains data for posts within collections.
 
 * `language`: *char2*. The post’s language.
 
-* `rtl`: *tinyint(1)*. Value is 1 if language is right to left (e.g. Arabic).  Otherwise null.
+* `rtl`: *tinyint(1)*. Value is 0 if the post is written left-to-right, 1 if written right-to-left (e.g. Arabic), and null if user never explicitly provided this value.
 
 * `privacy`: **Not currently used.**
 
 * `owner_id`: *int(6)*.  Id of the author.  Id is instance-specific.
 
-* `collection_id`: *int(6)*.  Id of the blog.  Id is instance-specific.
+* `collection_id`: *int(6)*.  Id of the blog.  Id is instance-specific. Null if post is a Draft.
 
 * `pinned_position`: *tinyint(1)*.  The order the post is "pinned" (zero-indexed).  Null if not pinned.
 
@@ -103,7 +103,7 @@ Table that contains user data.
 
 * `password`: *char(60)*.  **Cannot be null**.  Salted and hashed password.
 
-* `email`: *varbinary(255)*.  Email (null if not given by user).
+* `email`: *varbinary(255)*.  Encrypted email address. (null if not given by user).
 
 * `created`: *datetime*.  **Cannot be null**.  Date and time account was created.
 

--- a/developer/database.md
+++ b/developer/database.md
@@ -1,0 +1,102 @@
+# Database Values
+
+The following is a description of the various database tables and attributes.  (This document is not yet complete).
+
+## `accesstokens`
+Filled when someone logs in with the API.
+
+## `appcontent`
+Populated when the About and Privacy page are edited.
+
+## `appmigrations`
+
+## `collectionattributes`
+Used for additional properties on collections.
+
+## `collectionkeys`
+
+## `collectionpasswords`
+
+## `collectionredirects`
+
+## `collections`
+Table that contains collections (i.e. "Blogs").
+
+* `id`: *int(6)*. **Primary Key**.  Blog id.  Instance specific.
+
+* `alias`: *varchar(100)*.  Blog identifier based on the blog’s title when created.
+
+* `title`: *varchar(255*. **Cannot be null**.  Blog name.
+
+* `description`: *varchar(160)*. **Cannot be null**.  User defined description of blog.
+
+* `style_sheet`: *text*.  CSS stylesheet data goes here.
+
+* `script`: *text*.  **Currently unused.**
+
+* `format`: *varchar(8)*.  User defined format (`blog`, `novel`, or `notebook`).
+
+* `privacy`: *tinyint(1)*. **Cannot be null**. 0=Unlisted. 2=Private. 4=Password Protected.
+
+* `owner_id`: *int(6)*.  **Cannot be null**.  The id of the user that published this collection.
+
+* `view_count`: *int(6)*.  **Cannot be null**.  How many views this collection has.
+
+## `posts`
+Table that contains data for posts within collections.
+
+* `id`: **Primary Key.** *Char(16)*.  Randomly generated id.
+
+* `slug`: *varchar(100)*.  Identifier for post.  Smartly generated based on post content, favoring: Title > Text > Id.
+
+* `modify_token`: *char(32)*.
+
+* `text_appearance`: *char(4)*. **Cannot be null**.  Font class (Serif=`norm`, Sans-serif=`sans`, Monospace=`wrap`)
+
+* `language`: *char2*. The post’s language.
+
+* `rtl`: *tinyint(1)*. Value is 1 if language is right to left (e.g. Arabic).  Otherwise null.
+
+* `privacy`: **Not currently used.**
+
+* `owner_id`: *int(6)*.  Id of the author.  Id is instance-specific.
+
+* `collection_id`: *int(6)*.  Id of the blog.  Id is instance-specific.
+
+* `pinned_position`: *tinyint(1)*.  The order the post is "pinned" (zero-indexed).  Null if not pinned.
+
+* `created`: *timestamp*.  **Cannot be null**.  Time and date of first publish
+
+* `updated`: *timestamp*.  **Cannot be null**.  Time and date of last edit
+
+* `view_count`: *int(6)*.  **Cannot be null**.  How many views this post has.
+
+* `title`: *varchar(160)*.  **Cannot be null**.  Title, if author created one (may be empty string).
+
+* `content`: *text*.  **Cannot be null**.  The content of the post in plain text.
+
+## `remotefollows`
+
+## `remoteuserkeys`
+
+## `remoteusers`
+
+## `userattributes`
+
+## `userinvites`
+
+## `users`
+Table that contains user data.
+
+* `id`: *int(6)*. **Primary Key**. User id.  Instance specific.
+
+* `username`: *varchar(100)*.  **Cannot be null**.  Chosen username.
+
+* `password`: *char(60)*.  **Cannot be null**.  Salted and hashed password.
+
+* `email`: *varbinary(255)*.  Email (null if not given by user).
+
+* `created`: *datetime*.  **Cannot be null**.  Date and time account was created.
+
+## `usersinvited`
+


### PR DESCRIPTION
### Problem
As of now, there exists no documentation explaining the database schema of writefreely.  This can make administration of an instance more difficult, as well as slows down development efforts that require interaction with the database.

### Solution
This merge will add a new page to project documentation that explains each piece of the database schema.  To start, only the `collections`, `posts`, and `users` sections are completed, with some placeholder text in other areas.  The rest of the documentation can be filled out at a later date as devs and contributors work with these pieces of the database schema (or in one shot if someone is so inclined).

### Review
Please check the accuracy of descriptions for each of these attributes.  While I spent some time examining the code and doing some tests with my own dev instance, I'm not as familiar with the codebase as would be ideal.  Corrections should be made where inaccuracies are found to avoid future confusion in the development process.

I made a decision when I drafted this document to leave headers as placeholders for unfinished sections.  While this does create some clutter in the short-term, I believe this will serve as a visual reminder that parts of this document are unfinished and need to be completed.  If this is not desired, they can be removed for immediate cleaner documentation.