### PR TITLE
Clean up section where Markdown gets parsed oddly

### DIFF
--- a/writer/writing.md
+++ b/writer/writing.md
@@ -150,7 +150,7 @@ Download the command-line client and run `./writeas new`
 
 ### Syntax-highlighted Code Blocks
 
-<pre><code>```go
+<pre>```go
 package main
 
 import "fmt"
@@ -158,7 +158,7 @@ import "fmt"
 func main() {
 	fmt.Println("Hello, world")
 }
-```</pre></code>
+```</pre>
 
 ```go
 package main


### PR DESCRIPTION
Hi WriteFreely team! I'm setting up a test instance and as such have been deep in your documentation for the last few days, and I thought I'd contribute some small changes where I see issues.

This issue can be seen on the live site here: https://writefreely.org/docs/v0.13.1/writer/writing.md

The final section on how to produce code blocks in markdown gets parsed oddly/doesn't show the intended syntax highlighting when it makes it onto the page (markdown previews render it as intended though). I removed the `<code>` tags and tested the markdown on my WF instance, and it should now render correctly.

Thanks for all your work! You'll probably see a few of these small documentation pulls from me.