### PR TITLE
Fix installation command in Development Setup

### DIFF
--- a/developer/setup.md
+++ b/developer/setup.md
@@ -12,9 +12,9 @@ Ready to hack on your site? Here's a quick overview.
 After installing Go and Node.js, run the following commands to build, configure, and run the application.
 
 ```bash
-go get -d github.com/writefreely/writefreely/cmd/writefreely
+go install github.com/writefreely/writefreely/cmd/writefreely@latest
 
-cd $GOPATH/src/github.com/writefreely/writefreely
+cd $GOPATH/pkg/mod/github.com/writefreely/writefreely@*
 
 make build   # Compile the application
 make install # Config, generate keys, setup database, install LESS compiler


### PR DESCRIPTION
When running `go get -d github.com/writefreely/writefreely/cmd/writefreely`, go outputs this:

```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'
```

In this PR, I have fixed the installation step in the "Development Setup" article, and the changing of the directory part too.